### PR TITLE
Add KICS security checks

### DIFF
--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -1,0 +1,43 @@
+---
+name: KICS Security Scan
+on:
+  workflow_dispatch:
+    inputs:
+      logLevel:
+        description: 'Log level'
+        required: true
+        default: 'warning'
+        type: choice
+        options:
+          - info
+          - warning
+          - debug
+  pull_request:
+  push:
+    branches:
+      - 'main'
+  merge_group:
+  schedule:
+    - cron: '15 6 * * 4'
+jobs:
+  kics:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Mkdir results-dir
+        # make sure results dir is created
+        run: mkdir -p results-dir
+      - name: run kics Scan
+        uses: Checkmarx/kics-github-action@cd1f3774406f7818e3f79b77b093fe2ebaaf5c1d #v2.1.12
+        with:
+          # path: 'roles,plugins'
+          path: '.'
+          fail_on: high
+          ignore_on_exit: results
+          output_formats: 'json,sarif'
+          output_path: results-dir
+      - name: Upload SARIF file
+        uses: github/codeql-action/upload-sarif@5378192d256ef1302a6980fffe5ca04426d43091 #v3.28.21
+        with:
+          sarif_file: results-dir/results.sarif


### PR DESCRIPTION
Implement code tests with KICS: https://kics.io/

This new workflow does the following:

Manually create an output directory
Use a predefined action to use the KICS security scanner on the whole
repository. Configured to output results in the beforementioned
directory.
Use another predefined action to upload the output in SARIF format so
GitHub can interpret and visualize all found issues.
The current configuration will not fail on any issues being detected.
Code to activate failing is still in the comments and can be re-enabled
as soon as we got the checks going and fixed the current issues.

If we enable failing on certain issue levels we should also require the
check to succeed before merging. Currently it's just informational and
will not block merging.

Predefined GitHub actions now aren't refered to by their version tag.
Instead we use SHA checksums of Git commits. (as suggested by GitHub -
see below)

Please see comments from GitHub in this PR. They will make more clear
what this all is for.

Reference:

https://docs.kics.io/latest/integrations_ghactions/
Pin all GitHub Actions to a full length commit SHA https://github.com/carbon-design-system/carbon/issues/14052
https://github.com/Checkmarx/kics-github-action