### PR TITLE
Include "netways" branch in KICS

### DIFF
--- a/.github/workflows/kics.yml
+++ b/.github/workflows/kics.yml
@@ -16,6 +16,7 @@ on:
   push:
     branches:
       - 'main'
+      - 'netways'
   merge_group:
   schedule:
     - cron: '15 6 * * 4'


### PR DESCRIPTION
We missed that the default branch of this repository is called `netways`, not `main`. We plan to change it but we need to work with what we have for the time being.