### PR TITLE
Fix more KICS findings.

### DIFF
--- a/molecule/patroni-etcdv2-ssl/prepare.yml
+++ b/molecule/patroni-etcdv2-ssl/prepare.yml
@@ -75,6 +75,9 @@
       file:
         path: /etc/udev/rules.d
         state: directory
+        mode: 0755
+        owner: root
+        group: root
       when:
         - ansible_os_family == "RedHat" and ansible_distribution_major_version == "8" or
           ansible_os_family == "RedHat" and ansible_distribution_major_version == "9"

--- a/molecule/patroni-etcdv3-ssl/prepare.yml
+++ b/molecule/patroni-etcdv3-ssl/prepare.yml
@@ -47,6 +47,9 @@
       file:
         path: /etc/udev/rules.d
         state: directory
+        mode: 0755
+        owner: root
+        group: root
       when:
         - ansible_os_family == "RedHat" and ansible_distribution_major_version == "8" or
           ansible_os_family == "RedHat" and ansible_distribution_major_version == "9"


### PR DESCRIPTION
Set permissions on udev directory created during Molecule check. Again not a real issue but we want to give good example.