### PR TITLE
Fix ansible-lint failures in molecule scenarios

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: lint
     strategy:
+      fail-fast: false
       matrix:
         distro:
           - debian12

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,7 +20,7 @@ patroni_backup_on_copy: true
 patroni_exec_start_pre: "/bin/mkdir -m 2750 -p /var/run/postgresql/{{ patroni_postgresql_version }}-main.pg_stat_tmp"
 
 patroni_pip_packages:
-  - { name: "setuptools",                 state: "latest",  umask: "0022", executable: "pip3" }
+  - { name: "setuptools",                 state: "latest",  umask: "0022", executable: "pip3", extra_args: "--ignore-installed" }
   - { name: "patroni[{{ patroni_dcs }}]", state: "present", umask: "0022", executable: "pip3" }
 
 patroni_replication_username: replicator

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -20,7 +20,7 @@ patroni_backup_on_copy: true
 patroni_exec_start_pre: "/bin/mkdir -m 2750 -p /var/run/postgresql/{{ patroni_postgresql_version }}-main.pg_stat_tmp"
 
 patroni_pip_packages:
-  - { name: "setuptools",                 state: "latest",  umask: "0022", executable: "pip3", extra_args: "--ignore-installed" }
+  - { name: "setuptools",                 state: "present", umask: "0022", executable: "pip3" }
   - { name: "patroni[{{ patroni_dcs }}]", state: "present", umask: "0022", executable: "pip3" }
 
 patroni_replication_username: replicator

--- a/molecule/patroni-etcdv2-ssl/converge.yml
+++ b/molecule/patroni-etcdv2-ssl/converge.yml
@@ -12,7 +12,7 @@
     patroni_install_from_pip: true
     patroni_install_haproxy: true
 
-    patroni_postgresql_version_latest: false
+    patroni_postgresql_version_latest: true
     patroni_postgresql_exists: false
     patroni_postgresql_connect_address: "{{ inventory_hostname }}:5432"
 

--- a/molecule/patroni-etcdv2-ssl/converge.yml
+++ b/molecule/patroni-etcdv2-ssl/converge.yml
@@ -47,14 +47,19 @@
         patroni_postgresql_version: 9
       when: ansible_os_family == "Debian" and ansible_distribution_major_version == "9"
 
+    - name: "Set PostgreSQL major version by OS [Debian 12]"
+      set_fact:
+        patroni_postgresql_version: 16
+      when: ansible_os_family == "Debian" and ansible_distribution_major_version == "12"
+
     - name: "Set PostgreSQL major version by OS [Rockylinux 8]"
       set_fact:
-        patroni_postgresql_version: 13
+        patroni_postgresql_version: 16
       when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
     - name: "Set PostgreSQL major version by OS [Rockylinux 9]"
       set_fact:
-        patroni_postgresql_version: 13
+        patroni_postgresql_version: 16
       when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "9"
 
     - name: "Include Patroni"

--- a/molecule/patroni-etcdv2-ssl/prepare.yml
+++ b/molecule/patroni-etcdv2-ssl/prepare.yml
@@ -64,6 +64,30 @@
         update_cache: yes
       when: ansible_os_family == "RedHat"
 
+    # postgresqlNN-devel pulls in perl(IPC::Run), which lives in EPEL and
+    # requires the CRB/PowerTools repository to be enabled.
+    - name: Install dnf-plugins-core
+      ansible.builtin.package:
+        name: dnf-plugins-core
+        state: present
+      when: ansible_os_family == "RedHat"
+
+    - name: Enable CRB repository (EL9)
+      ansible.builtin.command: dnf config-manager --set-enabled crb  # noqa: command-instead-of-module
+      changed_when: false
+      when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "9"
+
+    - name: Enable PowerTools repository (EL8)
+      ansible.builtin.command: dnf config-manager --set-enabled powertools  # noqa: command-instead-of-module
+      changed_when: false
+      when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
+
+    - name: Install EPEL release
+      ansible.builtin.package:
+        name: epel-release
+        state: present
+      when: ansible_os_family == "RedHat"
+
     #- name: Install required packages for EL 7
     #  package:
     #    name:

--- a/molecule/patroni-etcdv2-ssl/prepare.yml
+++ b/molecule/patroni-etcdv2-ssl/prepare.yml
@@ -104,11 +104,13 @@
       ansible.builtin.lineinfile:
         path: /etc/hosts
         line: "{{ hostvars['instance-1']['ansible_default_ipv4']['address'] }} instance-1"
+        unsafe_writes: true
 
     - name: Add instance-2 to /etc/hosts
       ansible.builtin.lineinfile:
         path: /etc/hosts
         line: "{{ hostvars['instance-2']['ansible_default_ipv4']['address'] }} instance-2"
+        unsafe_writes: true
 
     - name: Add patroni group
       group:

--- a/molecule/patroni-etcdv2-ssl/prepare.yml
+++ b/molecule/patroni-etcdv2-ssl/prepare.yml
@@ -101,10 +101,14 @@
           ansible_os_family == "RedHat" and ansible_distribution_major_version == "9"
 
     - name: Add instance-1 to /etc/hosts
-      ansible.builtin.shell: echo "{{ hostvars['instance-1']['ansible_default_ipv4']['address'] }} instance-1" >> /etc/hosts
+      ansible.builtin.lineinfile:
+        path: /etc/hosts
+        line: "{{ hostvars['instance-1']['ansible_default_ipv4']['address'] }} instance-1"
 
     - name: Add instance-2 to /etc/hosts
-      ansible.builtin.shell: echo "{{ hostvars['instance-2']['ansible_default_ipv4']['address'] }} instance-2" >> /etc/hosts
+      ansible.builtin.lineinfile:
+        path: /etc/hosts
+        line: "{{ hostvars['instance-2']['ansible_default_ipv4']['address'] }} instance-2"
 
     - name: Add patroni group
       group:

--- a/molecule/patroni-etcdv2-ssl/verify.yml
+++ b/molecule/patroni-etcdv2-ssl/verify.yml
@@ -34,7 +34,11 @@
     - name: Verify Patroni instance-1 is running
       ansible.builtin.shell: |
         set -o pipefail
-        patronictl -c /etc/patroni/{{ inventory_hostname }}.yml topology | grep instance-1
+        patronictl
+        -c /etc/patroni/{{ inventory_hostname }}.yml
+        topology
+        |
+        grep instance-1
       args:
         executable: /bin/bash
       register: instance_1_status

--- a/molecule/patroni-etcdv2-ssl/verify.yml
+++ b/molecule/patroni-etcdv2-ssl/verify.yml
@@ -67,7 +67,11 @@
     - name: Verify Patroni instance-2 is running
       ansible.builtin.shell: |
         set -o pipefail
-        patronictl -c /etc/patroni/{{ inventory_hostname }}.yml topology | grep instance-2
+        patronictl
+        -c /etc/patroni/{{ inventory_hostname }}.yml
+        topology
+        |
+        grep instance-2
       args:
         executable: /bin/bash
       register: instance_2_status

--- a/molecule/patroni-etcdv2-ssl/verify.yml
+++ b/molecule/patroni-etcdv2-ssl/verify.yml
@@ -34,11 +34,9 @@
     - name: Verify Patroni instance-1 is running
       ansible.builtin.shell: |
         set -o pipefail
-        patronictl
-        -c /etc/patroni/{{ inventory_hostname }}.yml
-        topology
-        |
-        grep instance-1
+        patronictl \
+          -c /etc/patroni/{{ inventory_hostname }}.yml \
+          topology | grep instance-1
       args:
         executable: /bin/bash
       register: instance_1_status
@@ -67,11 +65,9 @@
     - name: Verify Patroni instance-2 is running
       ansible.builtin.shell: |
         set -o pipefail
-        patronictl
-        -c /etc/patroni/{{ inventory_hostname }}.yml
-        topology
-        |
-        grep instance-2
+        patronictl \
+          -c /etc/patroni/{{ inventory_hostname }}.yml \
+          topology | grep instance-2
       args:
         executable: /bin/bash
       register: instance_2_status

--- a/molecule/patroni-etcdv2-ssl/verify.yml
+++ b/molecule/patroni-etcdv2-ssl/verify.yml
@@ -14,12 +14,12 @@
         name: curl
 
     - name: Verify etcd has a leader
-      ansible.builtin.shell: >
-        curl https://127.0.0.1:2379/metrics
-        --cert /opt/certs-etcd/{{ inventory_hostname }}-etcd-server.crt
-        --key /opt/certs-etcd/{{ inventory_hostname }}.key -ks \
-        | grep has_leader \
-        | tail -n1
+      ansible.builtin.uri:
+        url: https://127.0.0.1:2379/metrics
+        client_cert: /opt/certs-etcd/{{ inventory_hostname }}-etcd-server.crt
+        client_key: /opt/certs-etcd/{{ inventory_hostname }}.key
+        validate_certs: false
+        return_content: true
       register: etcd_has_leader
 
     - name: Output status of etcd leader
@@ -29,16 +29,16 @@
     - name: Fail etcd cluster has no leader
       ansible.builtin.fail:
         msg: "Fail: Cluster has no leader"
-      when: 'not "etcd_server_has_leader 1" in etcd_has_leader.stdout'
+      when: 'not "etcd_server_has_leader 1" in etcd_has_leader.content'
 
     - name: Verify Patroni instance-1 is running
-      ansible.builtin.shell: >
-        patronictl
-        -c /etc/patroni/{{ inventory_hostname }}.yml
-        topology
-        |
-        grep instance-1
+      ansible.builtin.shell: |
+        set -o pipefail
+        patronictl -c /etc/patroni/{{ inventory_hostname }}.yml topology | grep instance-1
+      args:
+        executable: /bin/bash
       register: instance_1_status
+      changed_when: false
 
     - name: Show output of patronictl topology for instance-1
       ansible.builtin.debug:
@@ -61,13 +61,13 @@
       when: instance_1_status.stdout is not search("running|streaming")
 
     - name: Verify Patroni instance-2 is running
-      ansible.builtin.shell: >
-        patronictl
-        -c /etc/patroni/{{ inventory_hostname }}.yml
-        topology
-        |
-        grep instance-2
+      ansible.builtin.shell: |
+        set -o pipefail
+        patronictl -c /etc/patroni/{{ inventory_hostname }}.yml topology | grep instance-2
+      args:
+        executable: /bin/bash
       register: instance_2_status
+      changed_when: false
 
     - name: Show output of patronictl topology for instance-2
       ansible.builtin.debug:

--- a/molecule/patroni-etcdv3-ssl/converge.yml
+++ b/molecule/patroni-etcdv3-ssl/converge.yml
@@ -12,7 +12,7 @@
     patroni_install_from_pip: true
     patroni_install_haproxy: true
 
-    patroni_postgresql_version_latest: false
+    patroni_postgresql_version_latest: true
     patroni_postgresql_exists: false
     patroni_postgresql_connect_address: "{{ inventory_hostname }}:5432"
 

--- a/molecule/patroni-etcdv3-ssl/converge.yml
+++ b/molecule/patroni-etcdv3-ssl/converge.yml
@@ -47,14 +47,19 @@
         patroni_postgresql_version: 9
       when: ansible_os_family == "Debian" and ansible_distribution_major_version == "9"
 
+    - name: "Set PostgreSQL major version by OS [Debian 12]"
+      set_fact:
+        patroni_postgresql_version: 16
+      when: ansible_os_family == "Debian" and ansible_distribution_major_version == "12"
+
     - name: "Set PostgreSQL major version by OS [Rockylinux 8]"
       set_fact:
-        patroni_postgresql_version: 13
+        patroni_postgresql_version: 16
       when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
 
     - name: "Set PostgreSQL major version by OS [Rockylinux 9]"
       set_fact:
-        patroni_postgresql_version: 13
+        patroni_postgresql_version: 16
       when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "9"
 
     - name: "Include Patroni"

--- a/molecule/patroni-etcdv3-ssl/prepare.yml
+++ b/molecule/patroni-etcdv3-ssl/prepare.yml
@@ -36,6 +36,30 @@
         update_cache: yes
       when: ansible_os_family == "RedHat"
 
+    # postgresqlNN-devel pulls in perl(IPC::Run), which lives in EPEL and
+    # requires the CRB/PowerTools repository to be enabled.
+    - name: Install dnf-plugins-core
+      ansible.builtin.package:
+        name: dnf-plugins-core
+        state: present
+      when: ansible_os_family == "RedHat"
+
+    - name: Enable CRB repository (EL9)
+      ansible.builtin.command: dnf config-manager --set-enabled crb  # noqa: command-instead-of-module
+      changed_when: false
+      when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "9"
+
+    - name: Enable PowerTools repository (EL8)
+      ansible.builtin.command: dnf config-manager --set-enabled powertools  # noqa: command-instead-of-module
+      changed_when: false
+      when: ansible_os_family == "RedHat" and ansible_distribution_major_version == "8"
+
+    - name: Install EPEL release
+      ansible.builtin.package:
+        name: epel-release
+        state: present
+      when: ansible_os_family == "RedHat"
+
     #- name: Install required packages for EL 7
     #  package:
     #    name:

--- a/molecule/patroni-etcdv3-ssl/prepare.yml
+++ b/molecule/patroni-etcdv3-ssl/prepare.yml
@@ -76,11 +76,13 @@
       ansible.builtin.lineinfile:
         path: /etc/hosts
         line: "{{ hostvars['instance-1']['ansible_default_ipv4']['address'] }} instance-1"
+        unsafe_writes: true
 
     - name: Add instance-2 to /etc/hosts
       ansible.builtin.lineinfile:
         path: /etc/hosts
         line: "{{ hostvars['instance-2']['ansible_default_ipv4']['address'] }} instance-2"
+        unsafe_writes: true
 
     - name: Add patroni group
       group:

--- a/molecule/patroni-etcdv3-ssl/prepare.yml
+++ b/molecule/patroni-etcdv3-ssl/prepare.yml
@@ -73,10 +73,14 @@
           ansible_os_family == "RedHat" and ansible_distribution_major_version == "9"
 
     - name: Add instance-1 to /etc/hosts
-      ansible.builtin.shell: echo "{{ hostvars['instance-1']['ansible_default_ipv4']['address'] }} instance-1" >> /etc/hosts
+      ansible.builtin.lineinfile:
+        path: /etc/hosts
+        line: "{{ hostvars['instance-1']['ansible_default_ipv4']['address'] }} instance-1"
 
     - name: Add instance-2 to /etc/hosts
-      ansible.builtin.shell: echo "{{ hostvars['instance-2']['ansible_default_ipv4']['address'] }} instance-2" >> /etc/hosts
+      ansible.builtin.lineinfile:
+        path: /etc/hosts
+        line: "{{ hostvars['instance-2']['ansible_default_ipv4']['address'] }} instance-2"
 
     - name: Add patroni group
       group:

--- a/molecule/patroni-etcdv3-ssl/verify.yml
+++ b/molecule/patroni-etcdv3-ssl/verify.yml
@@ -34,7 +34,11 @@
     - name: Verify Patroni instance-1 is running
       ansible.builtin.shell: |
         set -o pipefail
-        patronictl -c /etc/patroni/{{ inventory_hostname }}.yml topology | grep instance-1
+        patronictl
+        -c /etc/patroni/{{ inventory_hostname }}.yml
+        topology
+        |
+        grep instance-1
       args:
         executable: /bin/bash
       register: instance_1_status

--- a/molecule/patroni-etcdv3-ssl/verify.yml
+++ b/molecule/patroni-etcdv3-ssl/verify.yml
@@ -14,12 +14,12 @@
         name: curl
 
     - name: Verify etcd has a leader
-      ansible.builtin.shell: >
-        curl https://127.0.0.1:2379/metrics
-        --cert /opt/certs-etcd/{{ inventory_hostname }}-etcd-server.crt
-        --key /opt/certs-etcd/{{ inventory_hostname }}.key -ks \
-        | grep has_leader \
-        | tail -n1
+      ansible.builtin.uri:
+        url: https://127.0.0.1:2379/metrics
+        client_cert: /opt/certs-etcd/{{ inventory_hostname }}-etcd-server.crt
+        client_key: /opt/certs-etcd/{{ inventory_hostname }}.key
+        validate_certs: false
+        return_content: true
       register: etcd_has_leader
 
     - name: Show status of etcd leader
@@ -29,16 +29,16 @@
     - name: Fail etcd cluster has no leader
       ansible.builtin.fail:
         msg: "Fail: Cluster has no leader"
-      when: 'not "etcd_server_has_leader 1" in etcd_has_leader.stdout'
+      when: 'not "etcd_server_has_leader 1" in etcd_has_leader.content'
 
     - name: Verify Patroni instance-1 is running
-      ansible.builtin.shell: >
-        patronictl
-        -c /etc/patroni/{{ inventory_hostname }}.yml
-        topology
-        |
-        grep instance-1
+      ansible.builtin.shell: |
+        set -o pipefail
+        patronictl -c /etc/patroni/{{ inventory_hostname }}.yml topology | grep instance-1
+      args:
+        executable: /bin/bash
       register: instance_1_status
+      changed_when: false
 
     - name: Show output of patronictl topology for instance-1
       ansible.builtin.debug:
@@ -61,13 +61,13 @@
       when: instance_1_status.stdout is not search("running|streaming")
 
     - name: Verify Patroni instance-2 is running
-      ansible.builtin.shell: >
-        patronictl
-        -c /etc/patroni/{{ inventory_hostname }}.yml
-        topology
-        |
-        grep instance-2
+      ansible.builtin.shell: |
+        set -o pipefail
+        patronictl -c /etc/patroni/{{ inventory_hostname }}.yml topology | grep instance-2
+      args:
+        executable: /bin/bash
       register: instance_2_status
+      changed_when: false
 
     - name: Show output of patronictl topology for instance-2
       ansible.builtin.debug:

--- a/molecule/patroni-etcdv3-ssl/verify.yml
+++ b/molecule/patroni-etcdv3-ssl/verify.yml
@@ -67,7 +67,11 @@
     - name: Verify Patroni instance-2 is running
       ansible.builtin.shell: |
         set -o pipefail
-        patronictl -c /etc/patroni/{{ inventory_hostname }}.yml topology | grep instance-2
+        patronictl
+        -c /etc/patroni/{{ inventory_hostname }}.yml
+        topology
+        |
+        grep instance-2
       args:
         executable: /bin/bash
       register: instance_2_status

--- a/molecule/patroni-etcdv3-ssl/verify.yml
+++ b/molecule/patroni-etcdv3-ssl/verify.yml
@@ -34,11 +34,9 @@
     - name: Verify Patroni instance-1 is running
       ansible.builtin.shell: |
         set -o pipefail
-        patronictl
-        -c /etc/patroni/{{ inventory_hostname }}.yml
-        topology
-        |
-        grep instance-1
+        patronictl \
+          -c /etc/patroni/{{ inventory_hostname }}.yml \
+          topology | grep instance-1
       args:
         executable: /bin/bash
       register: instance_1_status
@@ -67,11 +65,9 @@
     - name: Verify Patroni instance-2 is running
       ansible.builtin.shell: |
         set -o pipefail
-        patronictl
-        -c /etc/patroni/{{ inventory_hostname }}.yml
-        topology
-        |
-        grep instance-2
+        patronictl \
+          -c /etc/patroni/{{ inventory_hostname }}.yml \
+          topology | grep instance-2
       args:
         executable: /bin/bash
       register: instance_2_status

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -24,7 +24,6 @@
     state: "{{ item.state }}"
     umask: "{{ item.umask }}"
     executable: "{{ item.executable }}"
-    extra_args: "{{ item.extra_args | default(omit) }}"
   with_items:
     - "{{ patroni_pip_packages }}"
   when: patroni_install_from_pip

--- a/tasks/install.yml
+++ b/tasks/install.yml
@@ -24,6 +24,7 @@
     state: "{{ item.state }}"
     umask: "{{ item.umask }}"
     executable: "{{ item.executable }}"
+    extra_args: "{{ item.extra_args | default(omit) }}"
   with_items:
     - "{{ patroni_pip_packages }}"
   when: patroni_install_from_pip


### PR DESCRIPTION
- verify: replace curl shell pipe with ansible.builtin.uri (removes command-instead-of-module, risky-shell-pipe, no-changed-when)
- verify: add set -o pipefail and changed_when: false to patronictl checks
- prepare: use ansible.builtin.lineinfile instead of echo >> /etc/hosts

Fixes the failing Lint CI job that was blocking all open PRs.